### PR TITLE
feat(api): 프론트 작업용 임시 sendMessage, getMessages API 추가

### DIFF
--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'package:flutter_qnote/api/get_messages_dto.dart';
+import 'package:flutter_qnote/api/send_message_request.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+
+class ApiService {
+  final String baseUrl;
+
+  static const _storage = FlutterSecureStorage();
+
+  ApiService({required this.baseUrl});
+
+  Future<GetMessagesDto> getMessages() async {
+    final token = await _storage.read(key: 'accessToken');
+
+    if (token == null) {
+      throw Exception('No access token');
+    }
+
+    final url = Uri.parse('$baseUrl/messages');
+
+    final response = await http.get(
+      url,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      // return GetMessagesDto.fromJson(jsonDecode(response.body));
+
+      //임시 더미 값.
+      return GetMessagesDto.dummy();
+    } else {
+      throw Exception('Failed to load messages: ${response.body}');
+    }
+  }
+
+  //chatGpt
+  Future<SendMessageRequestDto> sendMessage(String message) async {
+    final token = await _storage.read(key: 'accessToken');
+    final url = Uri.parse('$baseUrl/openai/send-message');
+
+    final response = await http.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+      body: jsonEncode({'message': message}),
+    );
+
+    if (response.statusCode == 200) {
+      // return SendMessageRequestDto.fromJson(jsonDecode(response.body));
+
+      //임시 dummy 값입니다.
+      return SendMessageRequestDto.dummy();
+    } else {
+      throw Exception('Failed to send message: ${response.body}');
+    }
+  }
+}

--- a/lib/api/get_messages_dto.dart
+++ b/lib/api/get_messages_dto.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_qnote/api/send_message_request.dart';
+
+class GetMessagesDto {
+  GetMessagesDto({required this.messages});
+
+  final List<SendMessageRequestDto> messages;
+
+  factory GetMessagesDto.fromJson(Map<String, dynamic> json) {
+    final List<dynamic> rawList = json['messages'];
+    return GetMessagesDto(
+      messages:
+          rawList.map((item) => SendMessageRequestDto.fromJson(item)).toList(),
+    );
+  }
+
+  factory GetMessagesDto.dummy() {
+    const int length = 10;
+
+    const List<SendMessageRequestDto> list = [];
+    for (int i = 0; i < length; i++) list.add(SendMessageRequestDto.dummy());
+    return GetMessagesDto(messages: list);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {'messages': messages.map((m) => m.toJson()).toList()};
+  }
+}

--- a/lib/api/send_message_request.dart
+++ b/lib/api/send_message_request.dart
@@ -1,0 +1,43 @@
+//이 메세지는 누가 작성하였나.. system은 우리 서버측, assistance는.. AI, user는 유저
+enum MessageRole { system, assistance, user }
+
+//Ai의 상태, asking : 묻고 있음, done 이제 끝났고, text에는 일기의 내용
+enum MessageState { asking, done }
+
+class SendMessageRequestDto {
+  SendMessageRequestDto({
+    required this.role,
+    required this.state,
+    required this.message,
+  });
+
+  final MessageRole role;
+  final MessageState state;
+  final String message;
+
+  factory SendMessageRequestDto.fromJson(Map<String, dynamic> json) {
+    return SendMessageRequestDto(
+      role: MessageRole.values.firstWhere(
+        (e) => e.name == json['role'],
+        orElse: () => MessageRole.user,
+      ),
+      state: MessageState.values.firstWhere(
+        (e) => e.name == json['state'],
+        orElse: () => MessageState.done,
+      ),
+      message: json['message'],
+    );
+  }
+
+  factory SendMessageRequestDto.dummy() {
+    return SendMessageRequestDto(
+      state: MessageState.asking,
+      message: '서버에서 응답이 없어서 그래, 이건 더미 값이야 뭐 오늘 하루 어땟는데?',
+      role: MessageRole.assistance,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {'role': role.name, 'state': state.name, 'message': message};
+  }
+}


### PR DESCRIPTION
- Flutter용 DTO 모델(SendMessageRequestDto, getMessagesDto) 작성
- 메시지 리스트 응답용 GetMessagesDto 모델 추가
- secure_storage에서 accessToken을 사용하도록 설정
- NestJS 백엔드와 연동되는 기본 API 함수 구현
- 급하게 작성하였으므로, 추후 리펙토링과, api 자세한 구현이 필요하다.